### PR TITLE
Add non-decorator syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,23 @@ Import and apply to any React component you want to start monitoring:
 import React, { Component } from 'react';
 import visualizeRender from 'react-render-visualizer-decorator';
 
+// Use with decorator syntax (legacy)
+// Learn more: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#why-legacy
 @visualizeRender
+export default class TodoItem extends Component {
+    render () {
+        // ...
+    }
+}
+
+// Or simply passing the component to the function
 class TodoItem extends Component {
     render () {
         // ...
     }
 }
+
+export default visualizeRender(TodoItem);
 ```
 Component will show up with a blue border box when being monitored.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ React Render Visualizer Decorator
 ============
 A visual way to see what is (re)rendering and why.
 
-ES7 decorator version ported from <https://github.com/redsunsoft/react-render-visualizer>
+Decorator (experimental ES201x syntax) version ported from <https://github.com/redsunsoft/react-render-visualizer>
 
 Features
 --------
@@ -25,8 +25,7 @@ Import and apply to any React component you want to start monitoring:
 import React, { Component } from 'react';
 import visualizeRender from 'react-render-visualizer-decorator';
 
-// Use with decorator syntax (legacy)
-// Learn more: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#why-legacy
+// Use with decorator syntax (experimental - learn more: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#why-legacy)
 @visualizeRender
 export default class TodoItem extends Component {
     render () {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A visual way to see what is (re)rendering and why.
 
 Decorator (experimental ES201x syntax) version ported from <https://github.com/redsunsoft/react-render-visualizer>
 
+[Learn more about the experimental decorator syntax](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#why-legacy).
+
 Features
 --------
 - Shows when component is being mounted or updated by highlighting (red for mount, yellow for update)
@@ -25,7 +27,7 @@ Import and apply to any React component you want to start monitoring:
 import React, { Component } from 'react';
 import visualizeRender from 'react-render-visualizer-decorator';
 
-// Use with decorator syntax (experimental - learn more: https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#why-legacy)
+// Use with the decorator syntax (experimental)
 @visualizeRender
 export default class TodoItem extends Component {
     render () {

--- a/index.js
+++ b/index.js
@@ -316,6 +316,8 @@ function visualizeRender (component) {
     component.renderLogDetail = null;
     component.renderLogRenderCount = null;
     component._updateRenderLogPositionTimeout = null;
+    
+    return component;
 }
 
 module.exports = visualizeRender;


### PR DESCRIPTION
Return modified component, so that when not using `@decorator` syntax, as it isn't set in stone, it works. By that, I mean wrapping component in the decorator function.

```javascript
export default visualizeRender(MyComponent)
// equal to 
@visualizeRender
export default class MyComponent ...
```